### PR TITLE
Update example to use aria-labelledby

### DIFF
--- a/content/blog/testing-lists-items-with-react-testing-library/index.mdx
+++ b/content/blog/testing-lists-items-with-react-testing-library/index.mdx
@@ -20,8 +20,8 @@ const fruits = ["Bananas", "Apples", "Strawberries", "Grapes", "Oranges"]
 function FruitList() {
   return (
     <section>
-      <h1>Fruits</h1>
-      <ul aria-label="fruits">
+      <h1 id="fruits-heading">Fruits</h1>
+      <ul aria-labelledby="fruits-heading">
         {fruits.map(fruit => (
           <li key={fruit}>{fruit}</li>
         ))}


### PR DESCRIPTION
It's generally preferred to use `aria-labelledby` instead of `aria-label` when the label text is visible on-screen, so that screen readers don't read it out twice.

With the existing example, screen readers will announce the heading "Fruits" and then announce the label for the list "fruits (6 items)"

Using `aria-labelledby` allows it to skip re-announcing "fruits" for the list