### PR TITLE
Reposition site as engineering-operator portfolio; publish CarbonSync post-mortem

### DIFF
--- a/content/blog/what-i-learned-shutting-down-carbonsync/index.mdx
+++ b/content/blog/what-i-learned-shutting-down-carbonsync/index.mdx
@@ -1,0 +1,67 @@
+---
+title: "What I learned shutting down CarbonSync"
+date: "2026-06-25T07:30:00.000Z"
+description: "We built a GenAI eco-design product people genuinely liked, and we shut it down anyway. What I learned about timing, distribution, and the difference between a problem people admire and one they fund."
+---
+
+Earlier this year we shut down CarbonSync. My co-founder Keerthana wrote the company's public wind-down statement, and you should [read hers first](https://www.linkedin.com/posts/keerthana-chandrashekar-41598240_its-taken-me-a-while-to-write-this-but-share-7457467969657454592-ag3G). She named the real problem: the people who decide which materials go into a product mostly sit outside the design team, and the change we were chasing needs a bigger ecosystem shift than one tool can drive.
+
+This is the operator's side of that story. The part I actually learned, not the part we pitched.
+
+CarbonSync was a GenAI tool for eco-design. The idea was to let a designer treat sustainability as a real design parameter, the same way they treat cost or weight, instead of a number someone reconstructs months later in a spreadsheet.
+
+I didn't set out to found a company. The honest version is messier than the founder story usually goes. After HealthifyMe, I had interviews lined up almost immediately. A few conversations in, I realised I didn't want another job. I wanted to build something of my own. So I started consulting for startups, helping them with hiring and setting up teams. A mutual connection introduced me to CarbonSync because they needed help. I came in as a consultant, liked the problem enough to stay, and it became mine.
+
+The problem was the right size. Big enough to matter, small enough that I believed I could solve it. And if I could make my corner of the world slightly better while making a living, that was a good trade.
+
+We didn't fail at the product. We failed at timing. That distinction is the whole post.
+
+## What worked
+
+I want to be honest about this part, because it's the part that still stings.
+
+We made the bad data work. Anyone who has touched sustainability data knows it's messy, incomplete, and inconsistent across sources. We built things on top of it that gave people real answers.
+
+We built products people liked. These weren't polite nods. Real feedback, asks for more, people who wanted it better instead of wanting it gone. People wanted the thing to exist.
+
+We moved fast. We ran experiments quickly, killed what didn't work, kept what did. We didn't fail because we didn't try. We tried hard, and we were good at it.
+
+So if the product was liked and the team executed, what killed it?
+
+## What broke
+
+We were building something futuristic, and we knew it. The whole bet rested on one assumption. EU regulation was coming, manufacturers knew it was coming, and they'd start solving for it early because they could see it heading their way.
+
+That's not how it went. The market was busy worrying about other things, political and economic noise that felt more urgent. Sustainability was the last thing on most buyers' minds. Knowing a problem is coming, and putting budget against it today, are two completely different things, and we'd bet the company on them being the same.
+
+And the tailwind we were counting on actually got weaker while we built. In 2025 the EU pushed its big sustainability reporting rules out to 2028 and watered them down under a simplification package. When the regulator itself blinks on the timeline, you have your answer about how urgent the market finds you.
+
+You could see it in how we tried to sell. We started with prosumers and design studios. They liked it, but the subscription was small and the scale was never going to add up. So we made the product enterprise ready and went after bigger checks. Same result, one level up. Champions who genuinely loved it, and couldn't get a yes.
+
+Here is the number I can't unsee. We were talking to a European enterprise doing around 500 million dollars in revenue. Their entire sustainability team was two people. Two. At that size, in Europe, where the regulation was supposed to be the strongest tailwind we had. That was the moment "wrong time" stopped being a worry and became a fact. If even they didn't have the budget or the people, the buyer we needed didn't exist yet.
+
+By then I'd been at it a year, my co-founder longer. We looked at what it would actually take to crack this, and the answer was a long runway. In this economy, betting on a long runway to wait for a market to mature isn't brave, it's just expensive. So we made the call to wind down. Not because it was wrong. Because it was early.
+
+## The thing I stopped believing
+
+I disagree with the common view that a problem everyone agrees is coming is a problem you can build a business on today.
+
+Every investor, every customer, every regulator agreed sustainability mattered and that the rules were coming. Agreement was never our problem. We had all the agreement in the world and no budget to go with it. Awareness is not demand. A regulation on the horizon creates conversations, not line items. The 500 million dollar company with two sustainability people wasn't confused about whether the problem was real. They just weren't going to pay for it this year, or likely the next.
+
+For engineers this one is worth sitting with, because we're the people most likely to get it wrong. We believe that if you build something good enough, the market shows up. We obsess over the product because it's the part we control. But the product was the easy part. We made bad data useful, shipped fast, and people liked it, and none of that could manufacture a buyer who had budget. Distribution and timing were the whole game, and they're the part most of us treat as someone else's job.
+
+## What I carry forward
+
+The first thing I'd validate now, before building anything, is whether it's a problem of today or a problem of tomorrow. Not "do you agree this matters," because everyone agrees everything matters. The real question is "do you have budget for this, this year, and who signs the check." We never pushed hard enough on that question early, because the answer might have stopped us, and we wanted to build.
+
+But here's where I keep arguing with myself, and I will not pretend I have it resolved.
+
+The clean lesson is "solve a problem people have today." And I mostly believe it. But with AI moving this fast, the safest-looking problem of today can be commoditised in a year, and some of the biggest opportunities are bets on a near future that doesn't quite exist yet. So the lesson isn't "never build for the future." It's harder than that. It's learning to tell the difference between early and wrong, and refusing to bet a whole company on a future arriving inside your runway unless you have something that pays the bills while you wait.
+
+I still think CarbonSync was early, not wrong. I still believe that product has a place, maybe a few years out, if the budgets and the teams ever catch up. Like Keerthana wrote, that's a bigger ecosystem shift, not just a calendar problem. I just will not be the one funding the wait.
+
+## Close
+
+I am not going to pretend there is a tidy moral here that makes it feel better. We built something good, people wanted it, and the market wasn't ready to pay for it yet. That is allowed to just be disappointing.
+
+What I took from it is sharper instincts about timing, distribution, and the difference between a problem people admire and a problem people fund. If you're building in sustainability, or any regulated, ahead-of-its-time space, or you're wrestling with that same today-versus-tomorrow call on an AI product, I'd like to compare notes. I'm at hello@balavishnuvj.com.

--- a/content/data/social-proof.json
+++ b/content/data/social-proof.json
@@ -1,0 +1,28 @@
+{
+  "metrics": [
+    { "number": "9", "label": "Years in Engineering" },
+    { "number": "35M+", "label": "Users Scaled" },
+    { "number": "3000+", "label": "LinkedIn Followers" }
+  ],
+  "testimonials": [
+    {
+      "quote": "Bala helped us figure out what was actually slowing us down and worked with the team to fix it. Our frontend architecture is in a much better place now.",
+      "name": "Founder",
+      "role": "Stealth Fintech Startup",
+      "type": "anonymized"
+    },
+    {
+      "quote": "He brought clarity to our technical roadmap when we really needed it. Our team ships faster and with a lot more confidence now.",
+      "name": "CTO",
+      "role": "Stealth HealthTech Startup",
+      "type": "anonymized"
+    },
+    {
+      "quote": "What I liked most is that Bala doesn't just tell you what to do — he gets in there and builds with you. Exactly what we needed at our stage.",
+      "name": "Co-founder",
+      "role": "Stealth EdTech Startup",
+      "type": "anonymized"
+    }
+  ],
+  "credibility": ["CarbonSync", "HealthifyMe", "Kuliza/Acko", "Open Source Contributor"]
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,13 +1,13 @@
 const projects = require("./content/data/projects.json")
+const socialProof = require("./content/data/social-proof.json")
 
 module.exports = {
   siteMetadata: {
-    title: `Balavishnu V J | Software Engineer`,
+    title: `Balavishnu V J | Engineer & ex-CTO`,
     author: {
       name: `Balavishnu V J`,
-      summary: `who lives and works in Bangalore India making world a better place by code.`,
     },
-    description: `Passionate about making the world a better place by solving problems using technology. Write to me at hello@balavishnuvj.com`,
+    description: `Balavishnu V J is a full-stack engineer and ex co-founder & CTO. He scaled systems to 35M+ users and now builds with GenAI in production. He writes about how software gets built and scaled.`,
     siteUrl: `https://balavishnuvj.com`,
     social: {
       email: "hello@balavishnuvj.com",
@@ -18,6 +18,7 @@ module.exports = {
       twitterId: "vjbalavishnu",
     },
     projects,
+    socialProof,
   },
   plugins: [
     `gatsby-plugin-styled-components`,
@@ -73,7 +74,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `Balavishnu V J | Software Engineer`,
+        name: `Balavishnu V J | Engineer & ex-CTO`,
         short_name: `Balavishnu`,
         start_url: `/`,
         background_color: `#ffffff`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2007,6 +2007,40 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@expo/devcert": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@expo/devcert/-/devcert-1.2.1.tgz",
@@ -2548,6 +2582,44 @@
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -4532,6 +4604,13 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/@vercel/webpack-asset-relocator-loader": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.3.tgz",
@@ -4980,6 +5059,13 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0",
+      "peer": true
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -5309,6 +5395,38 @@
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.12.1"
+      }
+    },
+    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-extract-comments": {
@@ -8106,6 +8224,63 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -8382,6 +8557,23 @@
         "eslint": "^7.5.0 || ^8.0.0"
       }
     },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -8495,6 +8687,24 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esprima": {
@@ -10960,6 +11170,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -12297,6 +12520,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -12644,6 +12877,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -24280,6 +24526,20 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/typeface-montserrat/-/typeface-montserrat-1.1.13.tgz",
       "integrity": "sha512-Pklkyj0e+K+6I/t0M6JBDBphpfJkF1k+3qd8qDnp9aVtCC7oGBQWTAcL6+5eArfGe7h73uPwyal73hEkf9YCUA=="
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/typography": {
       "version": "0.16.24",

--- a/src/components/CTAButton.js
+++ b/src/components/CTAButton.js
@@ -1,0 +1,57 @@
+import React from "react"
+import { Link } from "gatsby"
+import styled from "styled-components"
+import { rhythm } from "../utils/typography"
+
+const PrimaryCTAStyled = styled(Link)`
+  display: inline-block;
+  padding: ${rhythm(0.4)} ${rhythm(1)};
+  background-color: ${props => props.theme.primaryColor};
+  color: ${props => props.theme.ctaText};
+  border-radius: 4px;
+  text-decoration: none;
+  box-shadow: none;
+  font-weight: bold;
+  font-size: 16px;
+  text-align: center;
+  transition: opacity 0.2s ease;
+  &:hover {
+    opacity: 0.9;
+    color: ${props => props.theme.ctaText};
+  }
+`
+
+const SecondaryCTAStyled = styled(Link)`
+  display: inline-block;
+  padding: ${rhythm(0.4)} ${rhythm(1)};
+  background-color: transparent;
+  color: ${props => props.theme.primaryColor};
+  border: 2px solid ${props => props.theme.primaryColor};
+  border-radius: 4px;
+  text-decoration: none;
+  box-shadow: none;
+  font-weight: bold;
+  font-size: 16px;
+  text-align: center;
+  transition: background-color 0.2s ease, color 0.2s ease;
+  &:hover {
+    background-color: ${props => props.theme.primaryColor};
+    color: ${props => props.theme.ctaText};
+  }
+`
+
+export function PrimaryCTA({ to, children, ...props }) {
+  return (
+    <PrimaryCTAStyled to={to} {...props}>
+      {children}
+    </PrimaryCTAStyled>
+  )
+}
+
+export function SecondaryCTA({ to, children, ...props }) {
+  return (
+    <SecondaryCTAStyled to={to} {...props}>
+      {children}
+    </SecondaryCTAStyled>
+  )
+}

--- a/src/components/FullWidthBand.js
+++ b/src/components/FullWidthBand.js
@@ -1,0 +1,20 @@
+import styled from "styled-components"
+import { rhythm } from "../utils/typography"
+
+const FullWidthBand = styled.div`
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  background-color: ${props => props.bg || props.theme.primaryColor};
+`
+
+export const BandContent = styled.div`
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: ${rhythm(2)} ${rhythm(1)};
+`
+
+export default FullWidthBand

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -32,6 +32,23 @@ const PageLink = styled(BaseLink)`
   }
 `
 
+const ContactLink = styled(GatsbyLink)`
+  margin-left: 8px;
+  padding: 8px 20px;
+  background-color: ${props => props.theme.primaryColor};
+  color: ${props => props.theme.ctaText};
+  border-radius: 4px;
+  text-decoration: none;
+  box-shadow: none;
+  font-weight: bold;
+  font-size: 14px;
+  transition: opacity 0.2s ease;
+  &:hover {
+    opacity: 0.9;
+    color: ${props => props.theme.ctaText};
+  }
+`
+
 const MobilePageLink = styled(BaseLink)`
   color: white;
   padding: ${rhythm(1)} 0;
@@ -167,15 +184,16 @@ export default function Navigation({ toggleTheme }) {
           </LogoLink>
         </LeftSection>
         <RightSection>
-          {/* <PageLink to="/hire">Hire</PageLink> */}
-          <PageLink to="/ama" activeClassName="active">
-            #AskBala
+          <PageLink to="/case-studies" activeClassName="active">
+            Case Studies
+          </PageLink>
+          <PageLink to="/blog" activeClassName="active">
+            Blog
           </PageLink>
           <PageLink to="/about" activeClassName="active">
             About
           </PageLink>
-          <PageLink to="/projects">Projects</PageLink>
-          <PageLink to="/blog">Blogs</PageLink>
+          <ContactLink to="/contact">Contact</ContactLink>
           <ColorModeToggle toggle={toggleTheme} />
         </RightSection>
       </WebNav>
@@ -194,21 +212,18 @@ export default function Navigation({ toggleTheme }) {
           <MobilePageLink onClick={handleClose} to="/">
             Home
           </MobilePageLink>
-          <MobilePageLink onClick={handleClose} to="/ama">
-            #AskBala
-          </MobilePageLink>
-          <MobilePageLink onClick={handleClose} to="/about">
-            About
-          </MobilePageLink>
-          <MobilePageLink onClick={handleClose} to="/projects">
-            Projects
+          <MobilePageLink onClick={handleClose} to="/case-studies">
+            Case Studies
           </MobilePageLink>
           <MobilePageLink onClick={handleClose} to="/blog">
             Blog
           </MobilePageLink>
-          {/* <MobilePageLink onClick={handleClose} to="/hire">
-            Hire
-          </MobilePageLink> */}
+          <MobilePageLink onClick={handleClose} to="/about">
+            About
+          </MobilePageLink>
+          <MobilePageLink onClick={handleClose} to="/contact">
+            Contact
+          </MobilePageLink>
         </MobileMenu>
       )}
     </header>

--- a/src/components/SectionHeading.js
+++ b/src/components/SectionHeading.js
@@ -1,0 +1,17 @@
+import styled from "styled-components"
+import { rhythm } from "../utils/typography"
+
+export const SectionHeading = styled.h2`
+  font-size: ${rhythm(1)};
+  color: ${props => props.theme.primaryColor};
+  margin-bottom: ${rhythm(0.5)};
+  text-align: ${props => (props.center ? "center" : "left")};
+`
+
+export const SectionSubheading = styled.p`
+  font-size: 18px;
+  color: ${props => props.theme.quoteColor};
+  max-width: 600px;
+  margin-bottom: ${rhythm(1.5)};
+  ${props => props.center && "margin-left: auto; margin-right: auto; text-align: center;"}
+`

--- a/src/components/bio.js
+++ b/src/components/bio.js
@@ -29,10 +29,9 @@ const Bio = () => {
         siteMetadata {
           author {
             name
-            summary
           }
           social {
-            twitterFollow
+            linkedin
           }
         }
       }
@@ -66,10 +65,13 @@ const Bio = () => {
         />
       )}
       <P>
-        Written by <strong>{author.name}</strong>.{` `}
-        Follow him on <a href={social.twitterFollow}>Twitter </a>
-        to know what he is working on. Also, his opinions, thoughts and
-        solutions in Web Dev.
+        Written by <strong>{author.name}</strong>, an engineer and ex-CTO
+        building with GenAI. He writes about building and scaling software.
+        Find him on{` `}
+        <a href={social.linkedin} target="_blank" rel="noopener noreferrer">
+          LinkedIn
+        </a>
+        .
       </P>
     </div>
   )

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -1,18 +1,10 @@
-/**
- * SEO component that queries for data with
- *  Gatsby's useStaticQuery React hook
- *
- * See: https://www.gatsbyjs.org/docs/use-static-query/
- */
-
 import React from "react"
 import PropTypes from "prop-types"
 import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 import balavishnu from "../../content/assets/meta-balavishnu.png"
 
-
-const SEO = ({ description, lang, meta, title, image }) => {
+const SEO = ({ description, lang, meta, title, image, canonical, keywords }) => {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -23,6 +15,11 @@ const SEO = ({ description, lang, meta, title, image }) => {
             siteUrl
             social {
               twitterId
+              email
+              linkedin
+            }
+            author {
+              name
             }
           }
         }
@@ -31,7 +28,92 @@ const SEO = ({ description, lang, meta, title, image }) => {
   )
 
   const metaDescription = description || site.siteMetadata.description
-  const metaImage = image || balavishnu;
+  const metaImage = image || balavishnu
+  const siteUrl = site.siteMetadata.siteUrl
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Person",
+        name: site.siteMetadata.author.name,
+        url: siteUrl,
+        jobTitle: "Software Engineer & Engineering Leader",
+        description: metaDescription,
+        knowsAbout: [
+          "Generative AI",
+          "Applied AI",
+          "System Architecture",
+          "Engineering Leadership",
+          "React",
+          "JavaScript",
+        ],
+        alumniOf: {
+          "@type": "CollegeOrUniversity",
+          name: "VIT University",
+        },
+        sameAs: [
+          site.siteMetadata.social.linkedin,
+        ].filter(Boolean),
+        email: site.siteMetadata.social.email,
+        address: {
+          "@type": "PostalAddress",
+          addressLocality: "Bengaluru",
+          addressCountry: "IN",
+        },
+      },
+    ],
+  }
+
+  const allMeta = [
+    {
+      name: "description",
+      content: metaDescription,
+    },
+    {
+      property: "og:title",
+      content: title,
+    },
+    {
+      property: "og:description",
+      content: metaDescription,
+    },
+    {
+      property: "og:type",
+      content: "website",
+    },
+    {
+      property: "og:image",
+      content: `${siteUrl}${metaImage}`,
+    },
+    {
+      property: "twitter:image",
+      content: `${siteUrl}${metaImage}`,
+    },
+    {
+      name: "twitter:card",
+      content: "summary",
+    },
+    {
+      name: "twitter:creator",
+      content: site.siteMetadata.social.twitterId,
+    },
+    {
+      name: "twitter:title",
+      content: title,
+    },
+    {
+      name: "twitter:description",
+      content: metaDescription,
+    },
+  ]
+
+  if (keywords && keywords.length > 0) {
+    allMeta.push({
+      name: "keywords",
+      content: keywords.join(", "),
+    })
+  }
 
   return (
     <Helmet
@@ -40,56 +122,25 @@ const SEO = ({ description, lang, meta, title, image }) => {
       }}
       title={title}
       titleTemplate={`%s | ${site.siteMetadata.title}`}
-      meta={[
-        {
-          name: `description`,
-          content: metaDescription,
-        },
-        {
-          property: `og:title`,
-          content: title,
-        },
-        {
-          property: `og:description`,
-          content: metaDescription,
-        },
-        {
-          property: `og:type`,
-          content: `website`,
-        },
-        {
-          property: `og:image`,
-          content: `${site.siteMetadata.siteUrl}${metaImage}`,
-        },
-        {
-          property: `twitter:image`,
-          content: `${site.siteMetadata.siteUrl}${metaImage}`,
-        },
-        {
-          name: `twitter:card`,
-          content: `summary`,
-        },
-        {
-          name: `twitter:creator`,
-          content: site.siteMetadata.social.twitterId,
-        },
-        {
-          name: `twitter:title`,
-          content: title,
-        },
-        {
-          name: `twitter:description`,
-          content: metaDescription,
-        },
-      ].concat(meta)}
-    />
+      meta={allMeta.concat(meta)}
+      link={
+        canonical
+          ? [{ rel: "canonical", href: canonical }]
+          : []
+      }
+    >
+      <script key="ld-json" type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </script>
+    </Helmet>
   )
 }
 
 SEO.defaultProps = {
-  lang: `en`,
+  lang: "en",
   meta: [],
-  description: ``,
+  description: "",
+  keywords: [],
 }
 
 SEO.propTypes = {
@@ -97,6 +148,9 @@ SEO.propTypes = {
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string.isRequired,
+  image: PropTypes.string,
+  canonical: PropTypes.string,
+  keywords: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default SEO

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,104 +1,341 @@
 import React from "react"
 import styled from "styled-components"
 import { rhythm } from "../utils/typography"
-import { graphql, useStaticQuery } from "gatsby"
-import PageInfo from "../components/PageInfo"
 import SEO from "../components/seo"
+import { SectionHeading } from "../components/SectionHeading"
+import { PrimaryCTA } from "../components/CTAButton"
+import FullWidthBand, { BandContent } from "../components/FullWidthBand"
 import balavishnu from "../../content/assets/balavishnu-waterfall.png"
 
-const Container = styled.section`
-  padding: 0 ${rhythm(1)};
-`
+// ── Hero ──
 
-const ProjectsGrid = styled.section`
+const HeroGrid = styled.section`
   display: grid;
   grid-template-columns: 3fr 2fr;
   grid-gap: 32px;
+  padding: ${rhythm(2)} ${rhythm(1)} ${rhythm(1)};
   @media (max-width: 699px) {
     grid-template-columns: 1fr;
   }
 `
 
-const Highlighted = styled.span`
-  color: ${props => props.theme.primaryColor};
-  font-weight: 700;
+const HeroText = styled.div``
+
+const HeroTitle = styled.h1`
+  font-size: 2rem;
+  margin-bottom: ${rhythm(0.5)};
+  @media (max-width: 699px) {
+    font-size: 1.5rem;
+  }
+`
+
+const HeroSummary = styled.p`
+  font-size: 18px;
+  color: ${props => props.theme.quoteColor};
+  line-height: 1.6;
 `
 
 const Image = styled.img`
   border-radius: 8px;
+  width: ${rhythm(20)};
+  min-width: 10px;
+  margin: 0 ${rhythm(1)};
+  margin-bottom: -1px;
   @media (max-width: 699px) {
     width: ${rhythm(15)};
     margin: 0 auto;
     grid-row: 1;
   }
-  margin: 0 ${rhythm(1)};
-  width: ${rhythm(20)};
-  min-width: 10px;
-  margin-bottom: -1px;
 `
 
-export default function Projects({ ...props }) {
-  const data = useStaticQuery(
-    graphql`
-      query {
-        site {
-          siteMetadata {
-            social {
-              twitter
-            }
-          }
-        }
-      }
-    `
-  )
-  const {
-    site: {
-      siteMetadata: {
-        social: { twitter },
-      },
-    },
-  } = data
+// ── Career Timeline ──
+
+const TimelineSection = styled.section`
+  padding: ${rhythm(1)} ${rhythm(1)} ${rhythm(2)};
+`
+
+const TimelineCard = styled.div`
+  padding: ${rhythm(1.5)};
+  background-color: ${props => props.theme.cardBackground};
+  box-shadow: 2px 4px 10px 0 ${props => props.theme.shadowColor};
+  border-radius: 8px;
+  margin-bottom: ${rhythm(1)};
+  border-left: 3px solid ${props => props.theme.primaryColor};
+`
+
+const RoleHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  margin-bottom: ${rhythm(0.25)};
+`
+
+const RoleTitle = styled.h3`
+  color: ${props => props.theme.primaryColor};
+  font-size: 20px;
+  margin-bottom: 0;
+`
+
+const RolePeriod = styled.span`
+  font-size: 14px;
+  color: ${props => props.theme.quoteColor};
+`
+
+const RoleCompany = styled.p`
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: ${rhythm(0.5)};
+`
+
+const RoleDescription = styled.p`
+  font-size: 15px;
+  margin-bottom: ${rhythm(0.25)};
+`
+
+const HighlightList = styled.ul`
+  margin-bottom: 0;
+  li {
+    font-size: 14px;
+    margin-bottom: 4px;
+  }
+`
+
+// ── Skills Strip ──
+
+const SkillsSection = styled.section`
+  padding: ${rhythm(1)} ${rhythm(1)} ${rhythm(2)};
+`
+
+const SkillsGrid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+`
+
+const SkillBadge = styled.span`
+  font-size: 14px;
+  padding: 6px 16px;
+  border-radius: 20px;
+  background-color: ${props => props.theme.tagBackground};
+  color: ${props => props.theme.textColor};
+`
+
+// ── Education ──
+
+const EducationSection = styled.section`
+  padding: 0 ${rhythm(1)} ${rhythm(2)};
+`
+
+const EducationCard = styled.div`
+  padding: ${rhythm(1)};
+  background-color: ${props => props.theme.cardBackground};
+  box-shadow: 2px 4px 10px 0 ${props => props.theme.shadowColor};
+  border-radius: 8px;
+`
+
+const EducationTitle = styled.h3`
+  color: ${props => props.theme.primaryColor};
+  font-size: 18px;
+  margin-bottom: 4px;
+`
+
+const EducationDetail = styled.p`
+  font-size: 15px;
+  margin-bottom: 0;
+  color: ${props => props.theme.quoteColor};
+`
+
+// ── CTA Band ──
+
+const CTAContent = styled.div`
+  text-align: center;
+  padding: ${rhythm(0.5)} 0;
+  color: ${props => props.theme.ctaText};
+`
+
+const CTATitle = styled.h2`
+  color: ${props => props.theme.ctaText};
+  margin-bottom: ${rhythm(0.5)};
+`
+
+const CTAText = styled.p`
+  color: ${props => props.theme.ctaText};
+  margin-bottom: ${rhythm(1)};
+  opacity: 0.9;
+`
+
+// ── Data ──
+
+const careerHistory = [
+  {
+    title: "Software Engineer",
+    company: "Early-stage startup",
+    period: "Apr 2026 -- Present",
+    description:
+      "Shipping GenAI in production across infrastructure, backend, frontend, and applied AI.",
+    highlights: [
+      "Full-stack GenAI work, from infrastructure through to product",
+    ],
+  },
+  {
+    title: "Co-Founder & CTO",
+    company: "CarbonSync",
+    period: "Apr 2025 -- Apr 2026",
+    description:
+      "Co-founded a GenAI eco-design SaaS and built it from concept to launch.",
+    highlights: [
+      "Took the MVP from concept to launch",
+      "Hired and managed the engineering team",
+      "Owned architecture, infrastructure, and product engineering",
+    ],
+  },
+  {
+    title: "Senior Software Consultant",
+    company: "Freelance",
+    period: "May 2024 -- Apr 2025",
+    description:
+      "Consulted across FinTech, E-Commerce, and SaaS startups on architecture, performance, and team building.",
+    highlights: [
+      "FinTech AI MVP: Built 0-to-1 collections platform, hired 2 engineers, transferred ownership to in-house team",
+      "E-Commerce AI: Resolved critical performance bottlenecks on AI-driven platform",
+      "Influencer SaaS: Designed system architecture enabling rapid feature iteration",
+    ],
+  },
+  {
+    title: "Lead Software Engineer",
+    company: "HealthifyMe",
+    period: "Jan 2019 -- Apr 2024",
+    description:
+      "Led frontend engineering for India's largest health and fitness platform, scaling to 35M+ users.",
+    highlights: [
+      "Built and led a 10-member frontend engineering team",
+      "Cut deployment time from 25 minutes to 6 minutes",
+      "Brought CRM load time down from 2 minutes to 4 seconds",
+      "Shipped a GenAI Co-Pilot that improved coach response efficiency by 18%",
+      "Got the team writing TypeScript and tests across the frontend codebase",
+      "Led VaccinateMe (COVID-19 vaccine tracker) — scaled to millions of users",
+    ],
+  },
+  {
+    title: "Software Developer",
+    company: "Kuliza Technologies",
+    period: "Jun 2017 -- Dec 2018",
+    description:
+      "Worked on fintech products including Acko's first go-live product and a no-code loan solution.",
+    highlights: [
+      "Built Acko's first go-live insurance product",
+      "Developed a no-code loan origination solution",
+    ],
+  },
+]
+
+const skills = [
+  "JavaScript",
+  "TypeScript",
+  "Python",
+  "React",
+  "React Native",
+  "Remix",
+  "Next.js",
+  "Django",
+  "Node.js",
+  "AWS",
+  "GCP",
+  "Docker",
+  "CI/CD",
+  "System Architecture",
+  "Engineering Leadership",
+]
+
+// ── Component ──
+
+export default function About() {
   return (
-    <Container>
-      <SEO title="About Me" />
-      <PageInfo title="About Me" />
-      <ProjectsGrid>
-        <div>
-          <p>
-            Hello! I am <Highlighted>Balavishnu V J</Highlighted> 👋🏾(friends
-            call me Bala), software engineer with 3+ years of experience in
-            building web applications. I'm based out of Bengaluru(Bangalore),
-            India🌏.
-          </p>
-          <p>
-            Soon after graduation👨🏼‍🎓from Vellore Institute of Technology in{" "}
-            <Highlighted>
-              Bachelors of Technology (Computer Science and Engineering).
-            </Highlighted>{" "}
-            I started my journey as a Frontend Engineer at Kuliza Technologies
-            Pvt Ltd. I worked on different fintech products.
-          </p>
-          <p>
-            Now I work at HealthifyMe where we help you in achieving a healthier
-            lifestyle.
-          </p>
-          <p>
-            I also collaborate to bring out high performing digital products. I
-            am most passionate about JavaScript ❤️. Most often I use React⚛️,
-            React Native, NodeJS to bring products to life.
-          </p>
-          <p>
-            When I am not writing code you can find me taking apart gadgets,
-            watching movies or cooking 🥘. Also you can find me in discord
-            helping out folks 🥳
-          </p>
-          <p>
-            Tweet me pictures of your adorable pets 🐶{" "}
-            <a href={twitter}>@vjbalavishnu</a>
-          </p>
-        </div>
+    <>
+      <SEO
+        title="About"
+        description="Balavishnu V J is a full-stack engineer and ex co-founder & CTO who scaled systems to 35M+ users and now builds with GenAI in production."
+      />
+
+      {/* Hero */}
+      <HeroGrid>
+        <HeroText>
+          <HeroTitle>About Me</HeroTitle>
+          <HeroSummary>
+            I'm a full-stack engineer with nearly a decade of building and
+            scaling software. I led frontend engineering at HealthifyMe as it
+            grew past 35M users, then co-founded and was CTO of CarbonSync, a
+            GenAI eco-design startup. Today I'm hands-on building GenAI in
+            production.
+          </HeroSummary>
+          <HeroSummary>
+            I write about how software actually gets built and scaled. Based in
+            Bengaluru, India.
+          </HeroSummary>
+        </HeroText>
         <Image src={balavishnu} alt="Balavishnu V J" />
-      </ProjectsGrid>
-    </Container>
+      </HeroGrid>
+
+      {/* Career Journey */}
+      <TimelineSection>
+        <SectionHeading>Career Journey</SectionHeading>
+        {careerHistory.map((role, i) => (
+          <TimelineCard key={i}>
+            <RoleHeader>
+              <RoleTitle>{role.title}</RoleTitle>
+              <RolePeriod>{role.period}</RolePeriod>
+            </RoleHeader>
+            <RoleCompany>{role.company}</RoleCompany>
+            <RoleDescription>{role.description}</RoleDescription>
+            <HighlightList>
+              {role.highlights.map((item, j) => (
+                <li key={j}>{item}</li>
+              ))}
+            </HighlightList>
+          </TimelineCard>
+        ))}
+      </TimelineSection>
+
+      {/* Skills */}
+      <SkillsSection>
+        <SectionHeading>Skills & Technologies</SectionHeading>
+        <SkillsGrid>
+          {skills.map((skill, i) => (
+            <SkillBadge key={i}>{skill}</SkillBadge>
+          ))}
+        </SkillsGrid>
+      </SkillsSection>
+
+      {/* Education */}
+      <EducationSection>
+        <SectionHeading>Education</SectionHeading>
+        <EducationCard>
+          <EducationTitle>VIT University</EducationTitle>
+          <EducationDetail>
+            B.Tech, Computer Science and Engineering (2013 -- 2017)
+          </EducationDetail>
+        </EducationCard>
+      </EducationSection>
+
+      {/* Contact Band */}
+      <FullWidthBand>
+        <BandContent>
+          <CTAContent>
+            <CTATitle>Let's compare notes</CTATitle>
+            <CTAText>
+              I'm always glad to hear from people building with GenAI or working
+              on hard engineering problems at scale.
+            </CTAText>
+            <PrimaryCTA
+              to="/contact"
+              style={{ backgroundColor: "white", color: "#443868" }}
+            >
+              Get in touch
+            </PrimaryCTA>
+          </CTAContent>
+        </BandContent>
+      </FullWidthBand>
+    </>
   )
 }

--- a/src/pages/case-studies.js
+++ b/src/pages/case-studies.js
@@ -1,0 +1,251 @@
+import React from "react"
+import styled from "styled-components"
+import { rhythm } from "../utils/typography"
+import SEO from "../components/seo"
+import { SectionHeading } from "../components/SectionHeading"
+import { PrimaryCTA } from "../components/CTAButton"
+import FullWidthBand, { BandContent } from "../components/FullWidthBand"
+
+// ── Hero ──
+
+const Wrapper = styled.section`
+  padding: 0 ${rhythm(1)};
+`
+
+const HeroSection = styled.div`
+  text-align: center;
+  padding: ${rhythm(2)} 0 ${rhythm(1.5)};
+`
+
+const HeroTitle = styled.h1`
+  font-size: 2rem;
+  color: ${props => props.theme.textColor};
+  margin-bottom: ${rhythm(0.5)};
+  @media (max-width: 699px) {
+    font-size: 1.5rem;
+  }
+`
+
+const HeroSubtext = styled.p`
+  font-size: 18px;
+  color: ${props => props.theme.quoteColor};
+  max-width: 600px;
+  margin: 0 auto ${rhythm(1)};
+`
+
+// ── Case Study Cards ──
+
+const CaseStudiesGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-gap: 24px;
+  margin-bottom: ${rhythm(2)};
+  @media (max-width: 699px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const CaseStudyCard = styled.div`
+  padding: ${rhythm(1.5)};
+  background-color: ${props => props.theme.cardBackground};
+  box-shadow: 2px 4px 10px 0 ${props => props.theme.shadowColor};
+  border-radius: 8px;
+`
+
+const CardTag = styled.span`
+  display: inline-block;
+  font-size: 12px;
+  font-weight: bold;
+  text-transform: uppercase;
+  padding: 4px 12px;
+  border-radius: 12px;
+  background-color: ${props => props.theme.tagBackground};
+  color: ${props => props.theme.primaryColor};
+  margin-bottom: ${rhythm(0.5)};
+`
+
+const CardTitle = styled.h3`
+  color: ${props => props.theme.primaryColor};
+  font-size: 20px;
+  margin-bottom: 4px;
+`
+
+const CardRole = styled.p`
+  font-size: 14px;
+  color: ${props => props.theme.quoteColor};
+  font-style: italic;
+  margin-bottom: ${rhythm(0.5)};
+`
+
+const CardLabel = styled.p`
+  font-size: 13px;
+  font-weight: bold;
+  text-transform: uppercase;
+  color: ${props => props.theme.quoteColor};
+  margin-bottom: 4px;
+`
+
+const CardText = styled.p`
+  font-size: 15px;
+  margin-bottom: ${rhythm(0.5)};
+`
+
+const OutcomeList = styled.ul`
+  margin-bottom: 0;
+  li {
+    font-size: 14px;
+    margin-bottom: 4px;
+  }
+`
+
+// ── CTA Band ──
+
+const CTAContent = styled.div`
+  text-align: center;
+  padding: ${rhythm(0.5)} 0;
+  color: ${props => props.theme.ctaText};
+`
+
+const CTATitle = styled.h2`
+  color: ${props => props.theme.ctaText};
+  margin-bottom: ${rhythm(0.5)};
+`
+
+const CTAText = styled.p`
+  color: ${props => props.theme.ctaText};
+  margin-bottom: ${rhythm(1)};
+  opacity: 0.9;
+`
+
+// ── Data ──
+
+const caseStudies = [
+  {
+    tag: "FinTech",
+    title: "FinTech AI Collections Platform",
+    role: "Senior Software Consultant (Freelance, 2024)",
+    challenge:
+      "Build a 0-to-1 MVP for an AI-driven collections platform with no existing engineering team.",
+    outcomes: [
+      "Shipped production-ready MVP from scratch",
+      "Hired 2 engineers and onboarded them into the codebase",
+      "Successfully transferred full ownership to in-house team",
+    ],
+  },
+  {
+    tag: "E-Commerce",
+    title: "E-Commerce AI Performance",
+    role: "Senior Software Consultant (Freelance, 2024)",
+    challenge:
+      "Critical performance bottlenecks on an AI-driven e-commerce platform were impacting user experience and conversion.",
+    outcomes: [
+      "Identified and resolved critical performance bottlenecks",
+      "Optimized application performance across the stack",
+    ],
+  },
+  {
+    tag: "SaaS",
+    title: "Influencer Marketing SaaS",
+    role: "Senior Software Consultant (Freelance, 2024)",
+    challenge:
+      "Founding team needed a scalable system architecture to enable rapid iteration on their influencer marketing platform.",
+    outcomes: [
+      "Designed initial system architecture from the ground up",
+      "Enabled rapid feature iteration for the founding team",
+    ],
+  },
+  {
+    tag: "HealthTech",
+    title: "HealthifyMe — Scaling to 35M+ Users",
+    role: "Lead Software Engineer (2019--2024)",
+    challenge:
+      "Scale the frontend engineering org and infrastructure for India's largest health and fitness platform.",
+    outcomes: [
+      "Built and led a 10-member frontend engineering team",
+      "Reduced deployment time from 25 minutes to 6 minutes",
+      "Optimized CRM load time from 2 minutes to 4 seconds",
+      "Shipped GenAI Co-Pilot -- improved coach response efficiency by 18%",
+      "Achieved 50% fewer production issues through TypeScript and testing adoption",
+    ],
+  },
+  {
+    tag: "HealthTech",
+    title: "VaccinateMe — COVID-19 Vaccine Tracker",
+    role: "Lead Software Engineer at HealthifyMe (2021)",
+    challenge:
+      "Build and scale a high-traffic vaccine availability tracker during the peak of the COVID-19 pandemic in India.",
+    outcomes: [
+      "Launched rapidly during the pandemic",
+      "Scaled to millions of users tracking vaccine availability",
+    ],
+  },
+  {
+    tag: "CleanTech",
+    title: "CarbonSync — GenAI Eco-Design SaaS",
+    role: "Co-Founder & CTO (2025--2026)",
+    challenge:
+      "Build a GenAI-powered Eco-Design platform from concept, onboard initial design-house partners, and establish the engineering foundation.",
+    outcomes: [
+      "Launched the MVP and onboarded initial design-house partners",
+      "Hired and built the engineering team",
+      "Owned architecture, infrastructure, and product engineering",
+    ],
+  },
+]
+
+// ── Component ──
+
+export default function CaseStudies() {
+  return (
+    <Wrapper>
+      <SEO
+        title="Case Studies"
+        description="Real outcomes for real companies. Explore Balavishnu V J's consulting track record across FinTech, HealthTech, E-Commerce, and SaaS."
+      />
+
+      <HeroSection>
+        <HeroTitle>Case Studies</HeroTitle>
+        <HeroSubtext>
+          Real outcomes for real companies. Here's a look at the challenges
+          I've tackled and the results I've delivered.
+        </HeroSubtext>
+      </HeroSection>
+
+      <CaseStudiesGrid>
+        {caseStudies.map((study, i) => (
+          <CaseStudyCard key={i}>
+            <CardTag>{study.tag}</CardTag>
+            <CardTitle>{study.title}</CardTitle>
+            <CardRole>{study.role}</CardRole>
+            <CardLabel>Challenge</CardLabel>
+            <CardText>{study.challenge}</CardText>
+            <CardLabel>Key Outcomes</CardLabel>
+            <OutcomeList>
+              {study.outcomes.map((outcome, j) => (
+                <li key={j}>{outcome}</li>
+              ))}
+            </OutcomeList>
+          </CaseStudyCard>
+        ))}
+      </CaseStudiesGrid>
+
+      <FullWidthBand>
+        <BandContent>
+          <CTAContent>
+            <CTATitle>Working on something similar?</CTATitle>
+            <CTAText>
+              I'm always glad to compare notes with people building with GenAI or
+              scaling hard systems.
+            </CTAText>
+            <PrimaryCTA
+              to="/contact"
+              style={{ backgroundColor: "white", color: "#443868" }}
+            >
+              Get in touch
+            </PrimaryCTA>
+          </CTAContent>
+        </BandContent>
+      </FullWidthBand>
+    </Wrapper>
+  )
+}

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,0 +1,115 @@
+import React from "react"
+import styled from "styled-components"
+import { rhythm } from "../utils/typography"
+import SEO from "../components/seo"
+
+const Wrapper = styled.section`
+  padding: 0 ${rhythm(1)};
+  max-width: 640px;
+  margin: 0 auto;
+`
+
+const HeroSection = styled.div`
+  text-align: center;
+  padding: ${rhythm(2)} 0 ${rhythm(1)};
+`
+
+const HeroTitle = styled.h1`
+  font-size: 2rem;
+  color: ${props => props.theme.textColor};
+  margin-bottom: ${rhythm(0.5)};
+  @media (max-width: 699px) {
+    font-size: 1.5rem;
+  }
+`
+
+const HeroSubtext = styled.p`
+  font-size: 18px;
+  color: ${props => props.theme.quoteColor};
+  max-width: 600px;
+  margin: 0 auto;
+`
+
+const InfoList = styled.div`
+  padding: ${rhythm(1)} 0 ${rhythm(2)};
+`
+
+const InfoItem = styled.div`
+  margin-bottom: ${rhythm(1)};
+`
+
+const InfoLabel = styled.p`
+  font-weight: bold;
+  margin-bottom: 4px;
+  font-size: 14px;
+  color: ${props => props.theme.quoteColor};
+  text-transform: uppercase;
+`
+
+const InfoValue = styled.p`
+  margin-bottom: 0;
+  font-size: 16px;
+`
+
+const InfoLink = styled.a`
+  color: ${props => (props.theme.isDark ? "#80bafe" : "#007acc")};
+  box-shadow: none;
+`
+
+export default function Contact() {
+  return (
+    <Wrapper>
+      <SEO title="Contact" description="Get in touch with Balavishnu V J." />
+      <HeroSection>
+        <HeroTitle>Get in touch</HeroTitle>
+        <HeroSubtext>
+          I'm always glad to hear from people building with GenAI or working on
+          hard engineering problems at scale. Email or LinkedIn is the best way
+          to reach me.
+        </HeroSubtext>
+      </HeroSection>
+
+      <InfoList>
+        <InfoItem>
+          <InfoLabel>Email</InfoLabel>
+          <InfoValue>
+            <InfoLink href="mailto:hello@balavishnuvj.com">
+              hello@balavishnuvj.com
+            </InfoLink>
+          </InfoValue>
+        </InfoItem>
+
+        <InfoItem>
+          <InfoLabel>LinkedIn</InfoLabel>
+          <InfoValue>
+            <InfoLink
+              href="https://www.linkedin.com/in/balavishnuvj"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              linkedin.com/in/balavishnuvj
+            </InfoLink>
+          </InfoValue>
+        </InfoItem>
+
+        <InfoItem>
+          <InfoLabel>GitHub</InfoLabel>
+          <InfoValue>
+            <InfoLink
+              href="https://github.com/balavishnuvj"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              github.com/balavishnuvj
+            </InfoLink>
+          </InfoValue>
+        </InfoItem>
+
+        <InfoItem>
+          <InfoLabel>Location</InfoLabel>
+          <InfoValue>Bengaluru, India</InfoValue>
+        </InfoItem>
+      </InfoList>
+    </Wrapper>
+  )
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,179 +1,437 @@
 import React from "react"
+import { graphql, Link } from "gatsby"
 import balavishnu from "../../content/assets/balavishnu-new.png"
 import styled from "styled-components"
 import { rhythm } from "../utils/typography"
-import { graphql, Link, useStaticQuery } from "gatsby"
 import SEO from "../components/seo"
+import { PrimaryCTA, SecondaryCTA } from "../components/CTAButton"
+import { SectionHeading, SectionSubheading } from "../components/SectionHeading"
+import FullWidthBand, { BandContent } from "../components/FullWidthBand"
+import Clock from "../../content/assets/svg/clock.svg"
 
-const Container = styled.section`
+// ── Hero Section ──
+
+const HeroContainer = styled.section`
   display: flex;
   align-items: center;
-  height: 100%;
+  padding: ${rhythm(2)} ${rhythm(1)};
+  @media (max-width: 699px) {
+    flex-direction: column-reverse;
+    padding: ${rhythm(1)} ${rhythm(1)};
+    text-align: center;
+  }
+`
+
+const HeroContent = styled.div`
   flex: 1;
+`
+
+const HeroTitle = styled.h1`
+  font-size: 2.2rem;
+  margin-bottom: ${rhythm(0.5)};
+  line-height: 1.2;
+  @media (max-width: 699px) {
+    font-size: 1.6rem;
+  }
+`
+
+const HeroSubtext = styled.p`
+  font-size: 18px;
+  color: ${props => props.theme.quoteColor};
+  max-width: 520px;
+  margin-bottom: ${rhythm(1)};
+  @media (max-width: 699px) {
+    margin-left: auto;
+    margin-right: auto;
+  }
+`
+
+const HeroCTAs = styled.div`
+  display: flex;
+  gap: 16px;
   @media (max-width: 699px) {
     flex-direction: column;
+    align-items: center;
   }
 `
 
-const ContentWrapper = styled.article`
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  width: 100%;
-`
-
-const LeftSection = styled.section``
-
-const Info = styled.section`
-  padding: 0 ${rhythm(1)};
-`
-
-const Image = styled.img`
+const HeroImage = styled.img`
+  width: ${rhythm(8)};
+  height: auto;
+  border-radius: 50%;
+  margin-left: ${rhythm(2)};
   @media (max-width: 699px) {
-    display: none;
-  }
-  margin: 0 ${rhythm(1)};
-  width: ${rhythm(10)};
-  min-width: 10px;
-  margin-bottom: -1px;
-  height: 450px;
-`
-
-const MobileImageWrapper = styled.div`
-  @media (min-width: 700px) {
-    display: none;
-  }
-  position: relative;
-  &:after {
-    width: 100vw;
-    height: ${rhythm(4.5)};
-    position: absolute;
-    background-color: ${props => props.theme.primaryColor};
-    content: "";
-    bottom: 1px;
-    left: 0;
-    z-index: -1;
+    width: ${rhythm(5)};
+    margin: 0 auto ${rhythm(1)};
   }
 `
 
-const MobileImage = styled.img`
+// ── Credibility Strip ──
+
+const CredibilityStrip = styled.section`
+  display: flex;
+  justify-content: center;
+  gap: ${rhythm(2)};
+  padding: ${rhythm(1)} ${rhythm(1)};
+  flex-wrap: wrap;
+`
+
+const CredItem = styled.div`
+  text-align: center;
+`
+
+const CredNumber = styled.div`
+  font-size: 28px;
+  font-weight: bold;
+  color: ${props => props.theme.primaryColor};
+`
+
+const CredLabel = styled.div`
+  font-size: 13px;
+  color: ${props => props.theme.quoteColor};
+  text-transform: uppercase;
+`
+
+// ── Services Preview ──
+
+const ServicesSection = styled.section`
+  padding: ${rhythm(2)} ${rhythm(1)};
+`
+
+const ServicesGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 24px;
+  @media (max-width: 699px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const ServiceCard = styled(Link)`
+  padding: ${rhythm(1.5)};
+  background-color: ${props => props.theme.cardBackground};
+  box-shadow: 2px 4px 10px 0 ${props => props.theme.shadowColor};
+  border-radius: 8px;
+  text-decoration: none;
+  box-shadow: 2px 4px 10px 0 ${props => props.theme.shadowColor};
+  color: ${props => props.theme.textColor};
+  transition: transform 0.2s ease;
+  &:hover {
+    transform: translateY(-4px);
+  }
+`
+
+const ServiceCardTitle = styled.h3`
+  color: ${props => props.theme.primaryColor};
+  font-size: 18px;
+  margin-bottom: 8px;
+`
+
+const ServiceCardText = styled.p`
+  font-size: 14px;
+  color: ${props => props.theme.quoteColor};
+  margin-bottom: 0;
+`
+
+// ── Social Proof ──
+
+const SocialProofSection = styled.section`
+  padding: ${rhythm(2)} ${rhythm(1)};
+`
+
+const TestimonialsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 24px;
+  margin-bottom: ${rhythm(1.5)};
+  @media (max-width: 699px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const TestimonialCard = styled.blockquote`
+  padding: ${rhythm(1)};
+  background-color: ${props => props.theme.cardBackground};
+  box-shadow: 2px 4px 10px 0 ${props => props.theme.shadowColor};
+  border-radius: 8px;
+  margin: 0;
+  border-left: 3px solid ${props => props.theme.primaryColor};
+`
+
+const TestimonialQuote = styled.p`
+  font-size: 15px;
+  font-style: italic;
+  color: ${props => props.theme.quoteColor};
+  margin-bottom: ${rhythm(0.5)};
+`
+
+const TestimonialAuthor = styled.p`
+  font-size: 13px;
+  font-weight: bold;
+  margin-bottom: 0;
+`
+
+const TestimonialRole = styled.span`
+  font-weight: normal;
+  color: ${props => props.theme.quoteColor};
+`
+
+const CredibilityLogos = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: ${rhythm(1.5)};
+  flex-wrap: wrap;
+  padding-top: ${rhythm(0.5)};
+`
+
+const CredibilityBadge = styled.span`
+  font-size: 14px;
+  color: ${props => props.theme.quoteColor};
+  padding: 6px 16px;
+  border: 1px solid ${props => props.theme.shadowColor};
+  border-radius: 20px;
+`
+
+// ── Recent Blog Posts ──
+
+const BlogSection = styled.section`
+  padding: ${rhythm(2)} ${rhythm(1)};
+`
+
+const BlogGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 16px;
+  @media (max-width: 699px) {
+    grid-template-columns: 1fr;
+  }
+`
+
+const BlogArticle = styled.article`
+  padding: 20px;
+  background-color: ${props => props.theme.cardBackground};
+  box-shadow: 2px 4px 10px 0 ${props => props.theme.shadowColor};
+  border-radius: 8px;
+`
+
+const BlogLink = styled(Link)`
+  color: ${props => props.theme.textColor};
+  box-shadow: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+`
+
+const BlogTitle = styled.h4`
+  font-size: 16px;
+  margin: 0;
+  margin-bottom: 16px;
+  color: ${props => props.theme.primaryColor};
+  text-transform: none;
+  line-height: 1.5;
+`
+
+const BlogExcerpt = styled.p`
+  font-size: 14px;
+`
+
+const BlogFoot = styled.section`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  color: ${props => props.theme.quoteColor};
+  font-size: 10px;
+`
+
+const BlogTime = styled.p`
+  display: flex;
+  align-items: center;
+  margin: 0;
+`
+
+const ClockIcon = styled(Clock)`
+  .fill {
+    path {
+      fill: ${props => props.theme.socialIcons};
+    }
+  }
+  margin-right: 4px;
+`
+
+const ViewAllLink = styled(Link)`
   display: block;
-  margin: 0 auto;
-  width: ${rhythm(5)};
+  text-align: center;
+  margin-top: ${rhythm(1)};
+  color: ${props => props.theme.primaryColor};
+  font-weight: bold;
 `
 
-const NameText = styled.h1`
-  font-size: 2rem;
-  margin: 8px 0;
+// ── CTA Band ──
+
+const CTABandContent = styled.div`
+  text-align: center;
+  padding: ${rhythm(0.5)} 0;
 `
 
-const StripedBackground = styled.div`
-  position: relative;
-  @media (min-width: 699px) {
-    &:after {
-      width: 100vw;
-      height: 100%;
-      position: absolute;
-      background-color: ${props => props.theme.primaryColor};
-      content: "";
-      top: 0;
-      z-index: -1;
-      @media (min-width: 1200px) {
-        margin-left: calc(-1 * (calc((100vw - 1200px)) / 2));
+const CTABandTitle = styled.h2`
+  color: ${props => props.theme.ctaText};
+  margin-bottom: ${rhythm(0.5)};
+`
+
+const CTABandText = styled.p`
+  color: ${props => props.theme.ctaText};
+  margin-bottom: ${rhythm(1)};
+  opacity: 0.9;
+`
+
+// ── Component ──
+
+export default function Home({ data }) {
+  const socialProof = data.site.siteMetadata.socialProof
+  const posts = data.allMdx.edges.slice(0, 3)
+
+  return (
+    <>
+      <SEO title="Home" />
+
+      {/* Hero */}
+      <HeroContainer>
+        <HeroContent>
+          <HeroTitle>
+            Ex-co-founder &amp; CTO. Scaled products to 35M+ users. Now building
+            with GenAI.
+          </HeroTitle>
+          <HeroSubtext>
+            Nearly a decade building and scaling software, from leading teams at
+            scale to the startup trenches. Now I'm hands-on with GenAI in
+            production, and I write about how it actually gets built.
+          </HeroSubtext>
+          <HeroCTAs>
+            <PrimaryCTA to="/blog">Read the writing</PrimaryCTA>
+            <SecondaryCTA to="/about">About</SecondaryCTA>
+          </HeroCTAs>
+        </HeroContent>
+        <HeroImage src={balavishnu} alt="Balavishnu V J" />
+      </HeroContainer>
+
+      {/* Credibility Strip */}
+      <CredibilityStrip>
+        {socialProof.metrics.map((metric, i) => (
+          <CredItem key={i}>
+            <CredNumber>{metric.number}</CredNumber>
+            <CredLabel>{metric.label}</CredLabel>
+          </CredItem>
+        ))}
+      </CredibilityStrip>
+
+      {/* Where I've worked */}
+      <SocialProofSection>
+        <SectionHeading center>Where I've worked</SectionHeading>
+        <CredibilityLogos>
+          {socialProof.credibility.map((name, i) => (
+            <CredibilityBadge key={i}>{name}</CredibilityBadge>
+          ))}
+        </CredibilityLogos>
+      </SocialProofSection>
+
+      {/* Recent Blog Posts */}
+      <BlogSection>
+        <SectionHeading center>From the Blog</SectionHeading>
+        <SectionSubheading center>
+          Thoughts on engineering, architecture, and building products.
+        </SectionSubheading>
+        <BlogGrid>
+          {posts.map(({ node }) => {
+            const title = node.frontmatter.title || node.fields.slug
+            return (
+              <BlogArticle key={node.fields.slug}>
+                <BlogLink to={`/blog${node.fields.slug}`}>
+                  <div>
+                    <header>
+                      <BlogTitle>{title}</BlogTitle>
+                    </header>
+                    <section>
+                      <BlogExcerpt
+                        dangerouslySetInnerHTML={{
+                          __html:
+                            node.frontmatter.description || node.excerpt,
+                        }}
+                      />
+                    </section>
+                  </div>
+                  <BlogFoot>
+                    <BlogTime>
+                      <ClockIcon />
+                      {node.fields.timeToRead} mins
+                    </BlogTime>
+                    <span>{node.frontmatter.date}</span>
+                  </BlogFoot>
+                </BlogLink>
+              </BlogArticle>
+            )
+          })}
+        </BlogGrid>
+        <ViewAllLink to="/blog">View all posts &rarr;</ViewAllLink>
+      </BlogSection>
+
+      {/* Contact Band */}
+      <FullWidthBand>
+        <BandContent>
+          <CTABandContent>
+            <CTABandTitle>Building with GenAI, or at scale?</CTABandTitle>
+            <CTABandText>
+              I like comparing notes with people working on hard engineering and
+              AI problems. If that's you, I'd be glad to hear from you.
+            </CTABandText>
+            <PrimaryCTA
+              to="/contact"
+              style={{ backgroundColor: "white", color: "#443868" }}
+            >
+              Get in touch
+            </PrimaryCTA>
+          </CTABandContent>
+        </BandContent>
+      </FullWidthBand>
+    </>
+  )
+}
+
+export const pageQuery = graphql`
+  query {
+    site {
+      siteMetadata {
+        socialProof {
+          metrics {
+            number
+            label
+          }
+          testimonials {
+            quote
+            name
+            role
+            type
+          }
+          credibility
+        }
+      }
+    }
+    allMdx(sort: { frontmatter: { date: DESC } }, limit: 3) {
+      edges {
+        node {
+          excerpt
+          fields {
+            slug
+            timeToRead
+          }
+          frontmatter {
+            date(formatString: "MMMM DD, YYYY")
+            title
+            description
+          }
+        }
       }
     }
   }
 `
-
-const Description = styled.p`
-  @media (min-width: 699px) {
-    max-width: 600px;
-    margin-top: 40px;
-    color: ${props => props.theme.ctaText};
-  }
-  color: ${props => props.theme.textColor};
-  padding: ${rhythm(1.5)} ${rhythm(1)};
-  margin: 0;
-`
-
-export const H5 = styled.h5`
-  color: ${props => props.theme.primaryColor};
-  margin: 0;
-  margin-top: 8px;
-  margin-bottom: 28px;
-  font-size: 16px;
-`
-
-const HireMeLink = styled(Link)`
-  @media (min-width: 700px) {
-    display: none;
-  }
-  padding: 8px 36px;
-  width: 90%;
-  display: flex;
-  justify-content: center;
-  border-radius: 4px;
-  background-color: transparent;
-  border: 1px solid ${props => props.theme.primaryColor};
-  color: ${props => props.theme.primaryColor};
-  margin-left: ${rhythm(1)};
-  box-shadow: none;
-`
-
-const MessageLink = styled.a`
-  color: ${props => (props.theme.isDark ? "#003553" : "#58bbfd")};
-  font-weight: bold;
-`
-
-export default function Home({ ...props }) {
-  const data = useStaticQuery(
-    graphql`
-      query {
-        site {
-          siteMetadata {
-            social {
-              twitter
-            }
-          }
-        }
-      }
-    `
-  )
-  const {
-    site: {
-      siteMetadata: {
-        social: { twitter },
-      },
-    },
-  } = data
-  return (
-    <Container>
-      <SEO title="Home" />
-      <ContentWrapper>
-        <LeftSection>
-          <Info>
-            <NameText>BALAVISHNU V J </NameText>
-            <H5>Frontend Developer and a dog lover</H5>
-          </Info>
-          <MobileImageWrapper>
-            <MobileImage src={balavishnu} alt="Balavishnu V J" />
-          </MobileImageWrapper>
-          <StripedBackground>
-            <Description>
-              Balavishnu V J is a software engineer based in Bengaluru, India
-              specializing in building websites and applications. Passionate
-              about making the world a better place by solving problems using
-              technology.
-              <p style={{ margin: "16px 0" }}>
-                If you have any questions to be answered by Balavishnu. Ask them
-                on his AMA, <MessageLink href="/ama">#AskBala</MessageLink>.
-              </p>
-            </Description>
-          </StripedBackground>
-        </LeftSection>
-        <Image src={balavishnu} alt="Balavishnu V J" />
-      </ContentWrapper>
-      {/* <HireMeLink to="hire">Hire Me</HireMeLink> */}
-    </Container>
-  )
-}


### PR DESCRIPTION
Repositions balavishnuvj.com from a fractional-CTO consulting funnel into a pure-portfolio engineering-operator credibility surface, and publishes the CarbonSync post-mortem.

- Homepage: new operator hero; removed services grid, placeholder testimonials, and the discovery-call funnel
- SEO/structured data: Person entity; dropped ProfessionalService and fractional-CTO service types; retitled to "Engineer & ex-CTO"
- Deleted the /services page and removed it from navigation
- Rewrote /contact and /about; corrected the career timeline (CarbonSync wound down, current role generalized, freelance stint bounded)
- Kept case studies as work history; fixed stale CarbonSync status and removed the booking CTA
- Updated the blog byline to point to LinkedIn
- Added the "What I learned shutting down CarbonSync" post
