### PR TITLE
Fix flash of unstyled content (server-render styled-components CSS)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,7 +21,6 @@ module.exports = {
     socialProof,
   },
   plugins: [
-    `gatsby-plugin-styled-components`,
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -95,3 +95,20 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
     })
   }
 }
+
+// Register babel-plugin-styled-components ourselves (previously provided by
+// gatsby-plugin-styled-components, which we removed because its SSR style
+// collection was not injecting critical CSS with styled-components v6, causing
+// a flash of unstyled content). SSR style extraction now lives in gatsby-ssr.js.
+exports.onCreateBabelConfig = ({ actions, stage }) => {
+  actions.setBabelPlugin({
+    name: `babel-plugin-styled-components`,
+    options: {
+      displayName: true,
+      fileName: true,
+      minify: true,
+      transpileTemplateLiterals: true,
+      ssr: stage === `build-html` || stage === `build-javascript`,
+    },
+  })
+}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,4 +1,6 @@
 import React, { createElement } from "react"
+import { renderToString } from "react-dom/server"
+import { ServerStyleSheet } from "styled-components"
 import Layout from "./src/components/BaseLayout"
 import { THEMES, THEME_STORAGE_KEY } from "./src/constants/app"
 
@@ -26,4 +28,20 @@ export const wrapPageElement = ({ element, props }) => {
   // props provide same data to Layout as Page element will get
   // including location, data, etc - you don't need to pass it
   return <Layout {...props}>{element}</Layout>
+}
+
+// Collect styled-components critical CSS during SSR and inject it into the
+// document head, so the first paint is fully styled (no flash of unstyled
+// content). Uses the styled-components v6 collectStyles API.
+export const replaceRenderer = ({
+  bodyComponent,
+  replaceBodyHTMLString,
+  setHeadComponents,
+}) => {
+  const sheet = new ServerStyleSheet()
+  const bodyHTML = renderToString(sheet.collectStyles(bodyComponent))
+  const styleElements = sheet.getStyleElement()
+  sheet.seal()
+  replaceBodyHTMLString(bodyHTML)
+  setHeadComponents(styleElements)
 }


### PR DESCRIPTION
Pages were loading as unstyled text on cold loads: the styled-components SSR step was not injecting the component CSS into the head with styled-components v6, so styles only appeared after hydration (FOUC).

Fix: register babel-plugin-styled-components directly via onCreateBabelConfig and collect + inject critical CSS in gatsby-ssr.js using ServerStyleSheet.collectStyles. Verified with a production build: server-rendered head CSS now includes the component rules (data-styled tags present) instead of typography only.